### PR TITLE
Core: Add first implementation for discussion

### DIFF
--- a/src/Query.ts
+++ b/src/Query.ts
@@ -1,0 +1,113 @@
+import { Retrier } from "./Retrier"
+import { QueryObserver } from "./QueryObserver"
+
+export interface QueryState<TData, TError> {
+  data: TData | undefined
+  error: TError | null
+  status: "idle" | "error" | "loading" | "success"
+}
+
+export interface ErrorAction<TError> {
+  error: TError
+  type: "error"
+}
+
+export interface FetchAction {
+  type: "fetch"
+}
+
+export interface SuccessAction<TData> {
+  data: TData
+  type: "success"
+}
+
+export type Action<TData, TError> =
+  | ErrorAction<TError>
+  | FetchAction
+  | SuccessAction<TData>
+
+export type QueryFunction<TData> = () => TData | Promise<TData>
+
+export class Query<TData, TError> {
+  private state: QueryState<TData, TError>
+  private observers: QueryObserver[]
+  private queryFn: QueryFunction<TData>
+  private retrier?: Retrier<TData, TError>
+
+  constructor(queryFn: QueryFunction<TData>) {
+    this.observers = []
+    this.state = {
+      data: undefined,
+      error: null,
+      status: "idle",
+    }
+    this.queryFn = queryFn
+  }
+
+  addObserver(observer: QueryObserver): void {
+    if (this.observers.indexOf(observer) === -1) {
+      this.observers.push(observer)
+    }
+  }
+
+  fetch(): void {
+    this.dispatch({
+      type: "fetch",
+    })
+
+    this.retrier = new Retrier({
+      fn: this.queryFn,
+      onError: (error) => {
+        this.dispatch({
+          type: "error",
+          error,
+        })
+      },
+      onSuccess: (data) => {
+        this.dispatch({
+          type: "success",
+          data,
+        })
+      },
+    })
+  }
+
+  refetch(): void {
+    this.fetch()
+  }
+
+  reducer(
+    state: QueryState<TData, TError>,
+    action: Action<TData, TError>
+  ): QueryState<TData, TError> {
+    switch (action.type) {
+      case "error":
+        return {
+          ...state,
+          status: "error",
+          error: action.error,
+        }
+      case "fetch":
+        return {
+          ...state,
+          status: "loading",
+        }
+      case "success":
+        return {
+          ...state,
+          status: "success",
+          data: action.data,
+        }
+      default:
+        return state
+    }
+  }
+
+  private dispatch(action: Action<TData, TError>): void {
+    this.state = this.reducer(this.state, action)
+
+    this.observers.forEach((observer) => {
+      observer.onQueryUpdate(action)
+    })
+  }
+}

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -28,19 +28,21 @@ export type Action<TData, TError> =
 
 export type QueryFunction<TData> = () => TData | Promise<TData>
 
+const INITIAL_QUERY_STATE = {
+  data: undefined,
+  error: null,
+  status: "idle",
+}
+
 export class Query<TData, TError> {
-  private state: QueryState<TData, TError>
+  state: QueryState<TData, TError>
   private observers: QueryObserver[]
   private queryFn: QueryFunction<TData>
   private retrier?: Retrier<TData, TError>
 
   constructor(queryFn: QueryFunction<TData>) {
     this.observers = []
-    this.state = {
-      data: undefined,
-      error: null,
-      status: "idle",
-    }
+    this.state = INITIAL_QUERY_STATE as QueryState<TData, TError>
     this.queryFn = queryFn
   }
 
@@ -51,6 +53,10 @@ export class Query<TData, TError> {
   }
 
   fetch(): void {
+    if (this.state.status === "loading") {
+      return
+    }
+
     this.dispatch({
       type: "fetch",
     })
@@ -70,10 +76,6 @@ export class Query<TData, TError> {
         })
       },
     })
-  }
-
-  refetch(): void {
-    this.fetch()
   }
 
   reducer(

--- a/src/QueryObserver.ts
+++ b/src/QueryObserver.ts
@@ -1,7 +1,101 @@
+import { Action, Query, QueryFunction } from "./Query"
 import { Subscribable } from "./subscribable"
+import { shallowEqualObjects } from "./utils"
 
-export class QueryObserver extends Subscribable {
-  onQueryUpdate(data: unknown): void {
-    console.log(data)
+export type QueryObserverListener<TData, TError> = (
+  result: QueryResult<TData, TError>
+) => void
+
+export interface QueryResult<TData, TError> {
+  data: TData | undefined
+  error: TError | null
+  status: "idle" | "error" | "loading" | "success"
+  isLoading: boolean
+  isError: boolean
+  isSuccess: boolean
+}
+
+export interface QueryObserverOptions<TData, TError> {
+  fetchOnMount?: boolean
+  listeners: QueryObserverListener<TData, TError>[]
+}
+
+const INITIAL_QUERY_OBSERVER_RESULT = {
+  data: undefined,
+  error: null,
+  status: "idle",
+  isLoading: false,
+  isError: false,
+  isSuccess: false,
+}
+
+export class QueryObserver<
+  TData = unknown,
+  TError = unknown
+> extends Subscribable<QueryObserverListener<TData, TError>> {
+  private currentResult: QueryResult<TData, TError>
+  private query: Query<TData, TError>
+
+  constructor(
+    queryFn: QueryFunction<TData>,
+    options: QueryObserverOptions<TData, TError> = {
+      fetchOnMount: false,
+      listeners: [],
+    }
+  ) {
+    super()
+
+    this.currentResult = INITIAL_QUERY_OBSERVER_RESULT as QueryResult<
+      TData,
+      TError
+    >
+    this.query = new Query(queryFn)
+    // Observe our own query to get low-level updates of it
+    this.query.addObserver(this as QueryObserver)
+
+    for (const listener of options.listeners) {
+      this.subscribe(listener)
+    }
+
+    if (options.fetchOnMount) {
+      this.query.fetch()
+    }
+  }
+
+  onQueryUpdate(action: Action<TData, TError>): void {
+    const previousResult = this.currentResult
+
+    const { state } = this.query
+
+    const result: QueryResult<TData, TError> = {
+      data: state.data,
+      error: state.error,
+      status: state.status,
+      isLoading: action.type === "fetch",
+      isError: action.type === "error",
+      isSuccess: action.type === "success",
+    }
+
+    if (shallowEqualObjects(result, previousResult)) {
+      return
+    }
+
+    this.currentResult = result
+
+    this.notify(result)
+  }
+
+  fetch(): void {
+    this.query.fetch()
+  }
+
+  refetch(): void {
+    this.fetch()
+  }
+
+  private notify(result: QueryResult<TData, TError>): void {
+    this.listeners.forEach((listener) => {
+      listener(result)
+    })
   }
 }

--- a/src/QueryObserver.ts
+++ b/src/QueryObserver.ts
@@ -1,0 +1,7 @@
+import { Subscribable } from "./subscribable"
+
+export class QueryObserver extends Subscribable {
+  onQueryUpdate(data: unknown): void {
+    console.log(data)
+  }
+}

--- a/src/Retrier.ts
+++ b/src/Retrier.ts
@@ -1,0 +1,89 @@
+import { sleep } from "./utils"
+
+interface RetrierConfig<TData = unknown, TError = unknown> {
+  fn: () => TData | Promise<TData>
+  onError?: (error: TError) => void
+  onSuccess?: (data: TData) => void
+  retry?: boolean
+  retryDelay?: number
+  retryTimes?: number
+}
+
+const DEFAULT_RETRY_DELAY = 1000 // ms
+const DEFAULT_RETRY_TIMES = 3
+
+export class Retrier<TData = unknown, TError = unknown> {
+  failureCount: number
+  isResolved: boolean
+  promise: Promise<TData>
+
+  constructor(config: RetrierConfig<TData, TError>) {
+    this.isResolved = false
+    this.failureCount = 0
+    let promiseResolve: (data: TData) => void
+    let promiseReject: (error: TError) => void
+
+    this.promise = new Promise<TData>((outerResolve, outerReject) => {
+      promiseResolve = outerResolve
+      promiseReject = outerReject
+    })
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const resolve = (value: any) => {
+      if (!this.isResolved) {
+        this.isResolved = true
+        config.onSuccess?.(value)
+        promiseResolve(value)
+      }
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const reject = (error: any) => {
+      if (!this.isResolved) {
+        this.isResolved = true
+        config.onError?.(error)
+        promiseReject(error)
+      }
+    }
+
+    const run = () => {
+      if (this.isResolved) {
+        return
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let promiseOrValue: any
+
+      try {
+        promiseOrValue = config.fn()
+      } catch (err) {
+        promiseOrValue = Promise.reject(err)
+      }
+
+      Promise.resolve(promiseOrValue)
+        .then(resolve)
+        .catch((err) => {
+          if (this.isResolved) {
+            return
+          }
+
+          const retries = config.retryTimes ?? DEFAULT_RETRY_TIMES
+          const retryDelay = config.retryDelay ?? DEFAULT_RETRY_DELAY
+          const shouldRetry =
+            config?.retry || this.failureCount < retries || false
+
+          if (!shouldRetry) {
+            reject(err)
+            return
+          }
+
+          this.failureCount++
+
+          // eslint-disable-next-line @typescript-eslint/no-floating-promises
+          sleep(retryDelay).then(() => run())
+        })
+    }
+
+    run()
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,22 @@
-import { Query } from "./Query"
-
 import { QueryObserver } from "./QueryObserver"
 
-const fetchFn = (a = "a") => Promise.resolve({ json: a })
+const fetchFn = () =>
+  new Promise(function (resolve) {
+    setTimeout(resolve, 1000, "hello world!")
+  })
 
-const queryManager = new Query(fetchFn)
-const queryObserver = new QueryObserver()
+const fetchFnTwo = () =>
+  new Promise(function (_, reject) {
+    setTimeout(reject, 1000, new Error('Whoops'))
+  })
 
-queryManager.addObserver(queryObserver)
+const queryObserver = new QueryObserver(fetchFn, {
+  listeners: [(res) => console.log(res)],
+})
 
-queryManager.fetch()
+const queryObserverTwo = new QueryObserver(fetchFnTwo, {
+  listeners: [(res) => console.log(res)],
+})
+
+queryObserver.fetch()
+queryObserverTwo.fetch()

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,12 @@
-export function useQuery(): string {
-  return 'hi!'
-}
+import { Query } from "./Query"
+
+import { QueryObserver } from "./QueryObserver"
+
+const fetchFn = (a = "a") => Promise.resolve({ json: a })
+
+const queryManager = new Query(fetchFn)
+const queryObserver = new QueryObserver()
+
+queryManager.addObserver(queryObserver)
+
+queryManager.fetch()

--- a/src/subscribable.ts
+++ b/src/subscribable.ts
@@ -1,0 +1,34 @@
+type Listener = () => void
+
+export class Subscribable<TListener extends Function = Listener> {
+  protected listeners: TListener[]
+
+  constructor() {
+    this.listeners = []
+  }
+
+  subscribe(listener?: TListener): () => void {
+    const callback = listener || (() => undefined)
+
+    this.listeners.push(callback as TListener)
+
+    this.onSubscribe()
+
+    return () => {
+      this.listeners = this.listeners.filter((x) => x !== callback)
+      this.onUnsubscribe()
+    }
+  }
+
+  hasListeners(): boolean {
+    return this.listeners.length > 0
+  }
+
+  protected onSubscribe(): void {
+    // Override me!
+  }
+
+  protected onUnsubscribe(): void {
+    // Override me!
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,3 @@
+export type TData = unknown
+
+export type TError = unknown

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,5 @@
+export function sleep(timeout: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, timeout)
+  })
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,3 +3,20 @@ export function sleep(timeout: number): Promise<void> {
     setTimeout(resolve, timeout)
   })
 }
+
+/**
+ * Shallow compare objects. Only works with objects that always have the same properties.
+ */
+export function shallowEqualObjects<T>(a: T, b: T): boolean {
+  if ((a && !b) || (b && !a)) {
+    return false
+  }
+
+  for (const key in a) {
+    if (a[key] !== b[key]) {
+      return false
+    }
+  }
+
+  return true
+}


### PR DESCRIPTION
Adds a very hacky first implementation of the base classes for the `core` lib: `Retrier` and `Query`. Ended up making it a little bit more complex than what I'd like, but made it mainly while browsing `react-query`'s code (and many parts of this are slimmed down or straight-up ripped out from that codebase). 😅 

- `Retrier` is just an abstraction for a retry-with-delay pattern, in which as soon as the class is initialized, the query function is called, and retries automatically (if set). It exposes handlers to either handle success/error.
- `Query` manages the state of the query internally (if it's loading, errored out, or is successful). One thing to keep in mind about this class is that it's based on the [_Observer_](https://en.wikipedia.org/wiki/Observer_pattern) pattern—observers can add themselves to the instance of the `Query` class they have available and listen to state updates through the expected `onQueryUpdate` function.
- `QueryObserver` is just made to demonstrate this pattern. Not too sure we might wanna leave it with that name, but this class itself is also observable. It feels weird at first, but I think that allowing subscriptions to this class can let us build a "core" API (as in, usable without any frameworks)  for users while leaving `Query` as a low-level class. Not married to this though, as I wanna reduce complexity as much as possible.

The point of this PR is not to necessarily merge this implementation in its current state, but to allow for discussion in terms of how where do we take the lib from here. Right now, the lib is already around `2.83kb` minified (and gzipped `1.13kb`), so if we wanna make it really really small, we should choose to stop adding stuff soon or just water down the options so much we can assume a bunch of defaults, as we haven't gotten into caching yet. 😄 

Note that the `index.ts` file has some code in it—instead of setting up a testing example I did it here for the sake of speed—just do `yarn build` and then `node ./dist/mini-query.cjs.development.js` to see it run. Let's definitely set up a little example ASAP though haha